### PR TITLE
Add Dockerfile and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.qmake.stash
+*.o
+Makefile
+src/ngPost
+moc_*.cpp
+ui_*.h
+moc_predefs.h
+qrc_resources.cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Usage:
+# Assuming you want to share the "files" subdirectory
+# and your ngPost config is ngPost.docker.conf.
+# $ docker build -t ngpost .
+# $ docker run -it -v $PWD/files:/root/files -v $PWD/ngPost.docker.conf:/root/.ngPost ngpost ARGUMENTS
+
+FROM debian:10
+
+RUN sed -i 's/main$/main non-free/' /etc/apt/sources.list
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    git build-essential qt5-qmake qt5-default par2 rar ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /usr/src/ngPost
+WORKDIR /usr/src/ngPost/src
+
+ENV QT_SELECT=qt5-x86_64-linux-gnu
+RUN git clean -fx && qmake && make -j$(nproc)
+RUN ln -s /usr/src/ngPost/src/ngPost /usr/local/bin/ngPost
+
+WORKDIR /root
+VOLUME /root/files
+
+ENTRYPOINT [ "ngPost" ]

--- a/README_FR.md
+++ b/README_FR.md
@@ -168,10 +168,10 @@ Vous pouvez faire des Post Rapides durant la phase de Surveillance<br/>
 
 ### Comment compiler ngPost
 #### les dépendances:
-- build-essential (C++ compiler, libstdc++, make,...)
-- qt5-default (Qt5 libraries and headers)
-- qt5-qmake (to generate the moc files and create the Makefile)
-- libssl (v1.0.2 or v1.1) but it should be already installed on your system
+- build-essential (compilateur C++, libstdc++, make,...)
+- qt5-default (librairies Qt5 et headers)
+- qt5-qmake (pour générer les fichiers moc et créer le Makefile)
+- libssl (v1.0.2 or v1.1) mais devrait déjà être installée sur votre système
 
 #### Compilation:
 - allez dans le dossier **src** ou copiez le en **bin**

--- a/ngPost.docker.conf
+++ b/ngPost.docker.conf
@@ -1,0 +1,19 @@
+lang = EN
+
+nzbPath  = /root/files/nzb
+inputDir = /root/files/input
+TMP_DIR = /root/files/tmp
+POST_HISTORY = /root/files/history.csv
+RAR_PATH = /usr/bin/rar
+PAR2_PATH = /usr/bin/par2
+
+DISP_PROGRESS = BAR
+
+
+[server]
+host = news.example.com
+port = 443
+ssl  = true
+user = myUser
+pass = myPass
+connection = 30


### PR DESCRIPTION
Since I can't compile it easily on my headless server (installing qtqui requires installing a lot of things, even on Gentoo) I made a Docker image.

One future improvement could be installing something like parpar in addition to par2cmdline.