### PR TITLE
Create CI Releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,11 +26,22 @@ jobs:
       run: |
         mv ./ngPost.desktop ./src
         cd src
+        ls -ltrah
         /opt/qt512/bin/qmake
         make
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
         chmod +x linuxdeployqt-continuous-x86_64.AppImage
+        ls -ltrah
         ./linuxdeployqt-continuous-x86_64.AppImage ./ngPost.desktop -appimage -qmake=/opt/qt512/bin/qmake
+        ls -ltrah
+        # Remove trash
+        rm -rf ./hmi
+        rm -rf ./lang
+        rm -rf ./nntp
+        rm -rf ./resources
+        rm -rf ./utils
+        rm -rf ./linuxdeployqt-continuous-x86_64.AppImage
+        find ./ \( -name "moc_*" -or -name "*.o" -or -name "*.h" -or -name "*.cpp" -or -name "qrc_*" -or -name "Makefile*" -or -name "*.a" \) -exec rm -rf {} \;
     - name: Create Release
       id: create_release
       uses: meeDamian/github-release@2.0
@@ -42,7 +53,7 @@ jobs:
         name: Continuous build
         body: |
           Release ${{ github.sha }}
-        files: ./src/ngPost-*-x86_64.AppImage
+        files: ./src/ngPost-*-x86_64.AppImage/ngPost-*-x86_64.AppImage
         draft: false
         prerelease: true
         allow_override: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,6 @@ jobs:
         ls -ltrah
         /opt/qt512/bin/qmake
         make
-        wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
-        chmod +x linuxdeployqt-continuous-x86_64.AppImage
-        ls -ltrah
-        ./linuxdeployqt-continuous-x86_64.AppImage ./ngPost.desktop -appimage -qmake=/opt/qt512/bin/qmake
         ls -ltrah
         # Remove trash
         rm -rf ./hmi
@@ -40,8 +36,12 @@ jobs:
         rm -rf ./nntp
         rm -rf ./resources
         rm -rf ./utils
-        rm -rf ./linuxdeployqt-continuous-x86_64.AppImage
         find ./ \( -name "moc_*" -or -name "*.o" -or -name "*.h" -or -name "*.cpp" -or -name "qrc_*" -or -name "Makefile*" -or -name "*.a" \) -exec rm -rf {} \;
+        cd ..
+        wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
+        chmod +x linuxdeployqt-continuous-x86_64.AppImage
+        ls -ltrah ./src
+        ./linuxdeployqt-continuous-x86_64.AppImage ./src/ngPost.desktop -appimage -qmake=/opt/qt512/bin/qmake
     - name: Create Release
       id: create_release
       uses: meeDamian/github-release@2.0
@@ -53,7 +53,7 @@ jobs:
         name: Continuous build
         body: |
           Release ${{ github.sha }}
-        files: ./src/ngPost-*-x86_64.AppImage/ngPost-*-x86_64.AppImage
+        files: ./src/ngPost-*-x86_64.AppImage
         draft: false
         prerelease: true
         allow_override: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,7 @@ jobs:
       run: |
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
         chmod +x linuxdeployqt-continuous-x86_64.AppImage
-        ls -ltrah ${{ env.GITHUB_WORKSPACE }}
-        ./linuxdeployqt-continuous-x86_64.AppImage ${{ env.GITHUB_WORKSPACE }}/ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake
+        ./linuxdeployqt-continuous-x86_64.AppImage ./ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,29 +1,16 @@
-# This is a basic workflow to help you get started with Actions
-
 name: AppImage CI
-
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
     name: Build AppImage
     #Ubuntu 16.04 use glibc 2.23
     runs-on: ubuntu-16.04
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-
-    # Runs a single command using the runners shell
     - name: Setup QT environment
       env:
         DEBIAN_FRONTEND: noninteractive
@@ -34,9 +21,10 @@ jobs:
           build-essential \
           wget \
           qt512base
-    # Runs a set of commands using the runners shell
     - name: Build AppImage
       run: |
+        qmake
+        make
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
         chmod +x linuxdeployqt-continuous-x86_64.AppImage
         ./linuxdeployqt-continuous-x86_64.AppImage ./ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake
@@ -58,7 +46,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./ngPost.AppImage
         asset_name: ngPost_latest-x86_64.AppImage
         asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,6 @@ jobs:
     # Runs a set of commands using the runners shell
     - name: Build AppImage
       run: |
-        source /opt/qt*/bin/qt*-env.sh
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
         chmod +x linuxdeployqt-continuous-x86_64.AppImage
         ./linuxdeployqt-continuous-x86_64.AppImage ./ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Setup QT environment
       env:
         DEBIAN_FRONTEND: noninteractive
+        GITHUB_WORKSPACE: ${{ GITHUB_WORKSPACE }}
       run: |
         sudo add-apt-repository ppa:beineri/opt-qt-5.12.0-xenial -y
         sudo apt-get update -qq

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,10 +26,8 @@ jobs:
       run: |
         mv ./ngPost.desktop ./src
         cd src
-        ls -ltrah
         /opt/qt512/bin/qmake
         make
-        ls -ltrah
         # Remove trash
         rm -rf ./hmi
         rm -rf ./lang
@@ -39,11 +37,8 @@ jobs:
         cd ..
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
         chmod +x linuxdeployqt-continuous-x86_64.AppImage
-        ls -ltrah ./src
         ./linuxdeployqt-continuous-x86_64.AppImage ./src/ngPost.desktop -appimage -qmake=/opt/qt512/bin/qmake
-        ls -ltrah ./src
         mv ./ngPost-*-x86_64.AppImage ./ngPost-latest-x86_64.AppImage
-        ls -ltrah
     - name: Create Release
       id: create_release
       uses: meeDamian/github-release@2.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Setup QT environment
       env:
         DEBIAN_FRONTEND: noninteractive
-        _WORKSPACE: ${{ GITHUB_WORKSPACE }}
       run: |
         sudo add-apt-repository ppa:beineri/opt-qt-5.12.0-xenial -y
         sudo apt-get update -qq
@@ -40,8 +39,8 @@ jobs:
       run: |
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
         chmod +x linuxdeployqt-continuous-x86_64.AppImage
-        ls -ltrah ${{ _WORKSPACE }}
-        ./linuxdeployqt-continuous-x86_64.AppImage ${{ _WORKSPACE }}/ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake
+        ls -ltrah ${{ env.GITHUB_WORKSPACE }}
+        ./linuxdeployqt-continuous-x86_64.AppImage ${{ env.GITHUB_WORKSPACE }}/ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./src/ngPost.AppImage
+        asset_path: ./src/ngPost*.AppImage
         asset_name: ngPost_latest-x86_64.AppImage
         asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,68 @@
+# This is a basic workflow to help you get started with Actions
+
+name: AppImage CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    name: Build AppImage
+    #Ubuntu 16.04 use glibc 2.23
+    runs-on: ubuntu-16.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: Setup QT environment
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo add-apt-repository ppa:beineri/opt-qt-5.12.0-xenial -y
+        sudo apt-get update -qq
+        sudo apt install --assume-yes install \
+          build-essential \
+          wget \
+          qt512base \
+          fff
+        source /opt/qt*/bin/qt*-env.sh
+        
+
+    # Runs a set of commands using the runners shell
+    - name: Build AppImage
+      run: |
+        wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
+        chmod +x linuxdeployqt-continuous-x86_64.AppImage
+        ./linuxdeployqt-continuous-x86_64.AppImage ./ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: continuous
+        release_name: Continuous build
+        body: |
+          Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ./ngPost.AppImage
+        asset_name: ngPost_latest-x86_64.AppImage
+        asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,9 @@ jobs:
         sudo apt-get update -qq
         sudo apt --assume-yes install \
           build-essential \
-          wget \
-          qt512base
+          libgl1-mesa-dev \
+          qt512base \
+          wget
     - name: Build AppImage
       run: |
         cd src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        tag_name: continuous
-        release_name: Continuous build
+        tag: continuous
+        name: Continuous build
         body: |
           Release ${{ github.sha }}
         files: ./src/ngPost-*-x86_64.AppImage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
         ls -ltrah ./src
         ./linuxdeployqt-continuous-x86_64.AppImage ./src/ngPost.desktop -appimage -qmake=/opt/qt512/bin/qmake
         ls -ltrah ./src
+        mv ./ngPost-*-x86_64.AppImage ./ngPost-latest-x86_64.AppImage
         ls -ltrah
     - name: Create Release
       id: create_release
@@ -54,7 +55,7 @@ jobs:
         name: Continuous build
         body: |
           Release ${{ github.sha }}
-        files: ./ngPost-*-x86_64.AppImage
+        files: ./ngPost-latest-x86_64.AppImage
         draft: false
         prerelease: true
         allow_override: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         tag_name: continuous
         release_name: Continuous build
         body: |
-          Release ${{ github.ref }}
+          Release ${{ github.sha }}
         draft: false
         prerelease: true
     - name: Upload Release Asset
@@ -50,6 +50,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./src/ngPost*.AppImage
+        asset_path: ./src/ngPost-${{ github.sha:0:7 }}-x86_64.AppImage
         asset_name: ngPost_latest-x86_64.AppImage
         asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,6 @@ jobs:
         rm -rf ./hmi
         rm -rf ./lang
         rm -rf ./nntp
-        rm -rf ./resources
         rm -rf ./utils
         find ./ \( -name "moc_*" -or -name "*.o" -or -name "*.h" -or -name "*.cpp" -or -name "qrc_*" -or -name "Makefile*" -or -name "*.a" \) -exec rm -rf {} \;
         cd ..

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,8 @@ jobs:
       run: |
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
         chmod +x linuxdeployqt-continuous-x86_64.AppImage
-        ./linuxdeployqt-continuous-x86_64.AppImage ./ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake
+        ls -ltrah ${{ GITHUB_WORKSPACE }}
+        ./linuxdeployqt-continuous-x86_64.AppImage ${{ GITHUB_WORKSPACE }}/ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,23 +33,16 @@ jobs:
         ./linuxdeployqt-continuous-x86_64.AppImage ./ngPost.desktop -appimage -qmake=/opt/qt512/bin/qmake
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
+      uses: meeDamian/github-release@2.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         tag_name: continuous
         release_name: Continuous build
         body: |
           Release ${{ github.sha }}
+        files: ./src/ngPost-*-x86_64.AppImage
         draft: false
         prerelease: true
-    - name: Upload Release Asset
-      id: upload-release-asset 
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./src/ngPost-*-x86_64.AppImage
-        asset_name: ngPost_latest-x86_64.AppImage
-        asset_content_type: application/octet-stream
+        allow_override: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,12 +34,10 @@ jobs:
           build-essential \
           wget \
           qt512base
-        source /opt/qt*/bin/qt*-env.sh
-        
-
     # Runs a set of commands using the runners shell
     - name: Build AppImage
       run: |
+        source /opt/qt*/bin/qt*-env.sh
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
         chmod +x linuxdeployqt-continuous-x86_64.AppImage
         ./linuxdeployqt-continuous-x86_64.AppImage ./ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,11 +30,10 @@ jobs:
       run: |
         sudo add-apt-repository ppa:beineri/opt-qt-5.12.0-xenial -y
         sudo apt-get update -qq
-        sudo apt install --assume-yes install \
+        sudo apt --assume-yes install \
           build-essential \
           wget \
-          qt512base \
-          fff
+          qt512base
         source /opt/qt*/bin/qt*-env.sh
         
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ jobs:
         chmod +x linuxdeployqt-continuous-x86_64.AppImage
         ls -ltrah ./src
         ./linuxdeployqt-continuous-x86_64.AppImage ./src/ngPost.desktop -appimage -qmake=/opt/qt512/bin/qmake
+        ls -ltrah ./src
+        ls -ltrah
     - name: Create Release
       id: create_release
       uses: meeDamian/github-release@2.0
@@ -52,7 +54,7 @@ jobs:
         name: Continuous build
         body: |
           Release ${{ github.sha }}
-        files: ./src/ngPost-*-x86_64.AppImage
+        files: ./ngPost-*-x86_64.AppImage
         draft: false
         prerelease: true
         allow_override: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
           wget
     - name: Build AppImage
       run: |
+        mv ./ngPost.desktop ./src
         cd src
         /opt/qt512/bin/qmake
         make
@@ -49,6 +50,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./ngPost.AppImage
+        asset_path: ./src/ngPost.AppImage
         asset_name: ngPost_latest-x86_64.AppImage
         asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           qt512base
     - name: Build AppImage
       run: |
-        qmake
+        /opt/qt512/bin/bin/qmake
         make
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
         chmod +x linuxdeployqt-continuous-x86_64.AppImage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,11 @@ jobs:
           qt512base
     - name: Build AppImage
       run: |
-        /opt/qt512/bin/bin/qmake
+        /opt/qt512/bin/qmake
         make
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
         chmod +x linuxdeployqt-continuous-x86_64.AppImage
-        ./linuxdeployqt-continuous-x86_64.AppImage ./ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake
+        ./linuxdeployqt-continuous-x86_64.AppImage ./ngPost.desktop -appimage -qmake=/opt/qt512/bin/qmake
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Setup QT environment
       env:
         DEBIAN_FRONTEND: noninteractive
-        GITHUB_WORKSPACE: ${{ GITHUB_WORKSPACE }}
+        _WORKSPACE: ${{ GITHUB_WORKSPACE }}
       run: |
         sudo add-apt-repository ppa:beineri/opt-qt-5.12.0-xenial -y
         sudo apt-get update -qq
@@ -40,8 +40,8 @@ jobs:
       run: |
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
         chmod +x linuxdeployqt-continuous-x86_64.AppImage
-        ls -ltrah ${{ GITHUB_WORKSPACE }}
-        ./linuxdeployqt-continuous-x86_64.AppImage ${{ GITHUB_WORKSPACE }}/ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake
+        ls -ltrah ${{ _WORKSPACE }}
+        ./linuxdeployqt-continuous-x86_64.AppImage ${{ _WORKSPACE }}/ngPost.desktop -appimage -qmake=/opt/qt512/bin/bin/qmake
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./src/ngPost-${{ github.sha:0:7 }}-x86_64.AppImage
+        asset_path: ./src/ngPost-*-x86_64.AppImage
         asset_name: ngPost_latest-x86_64.AppImage
         asset_content_type: application/octet-stream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
           qt512base
     - name: Build AppImage
       run: |
+        cd src
         /opt/qt512/bin/qmake
         make
         wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage


### PR DESCRIPTION
Hi,

I created this workflow to build Linux binaries for every commit made on the master branch.

It does not include the par2 binary, the idea is to extend the functionality to generate binaries of all operating systems in the following pull requests.

Could you validate if the[ resulting binary](https://github.com/BakasuraRCE/ngPost/releases) meets the packaging characteristics?