### PR TITLE
Fix compiling problem

### DIFF
--- a/src/nntp/NntpArticle.cpp
+++ b/src/nntp/NntpArticle.cpp
@@ -23,6 +23,7 @@
 #include "nntp/NntpFile.h"
 #include "nntp/Nntp.h"
 #include "utils/Yenc.h"
+#include <cstring>
 #include <sstream>
 
 ushort NntpArticle::sNbMaxTrySending = 5;


### PR DESCRIPTION
On Archlinux I had this kind of problem while doing compilation:

```
nntp/NntpArticle.cpp: In constructor ‘NntpArticle::NntpArticle(NntpFile*, uint, qint64, qint64, const std::string*, bool)’:
nntp/NntpArticle.cpp:52:14: error: ‘strcpy’ is not a member of ‘std’; did you mean ‘strcpy’?
   52 |         std::strcpy(_subject, subject.c_str());
      |              ^~~~~~
In file included from /usr/include/qt/QtCore/qarraydata.h:44,
                 from /usr/include/qt/QtCore/qbytearray.h:46,
                 from /usr/include/qt/QtCore/qstring.h:50,
                 from /usr/include/qt/QtCore/quuid.h:43,
                 from /usr/include/qt/QtCore/QUuid:1,
                 from nntp/NntpArticle.h:23,
                 from nntp/NntpArticle.cpp:20:
/usr/include/string.h:141:14: note: ‘strcpy’ declared here
  141 | extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
      |              ^~~~~~
nntp/NntpArticle.cpp: In member function ‘void NntpArticle::yEncBody(const char*)’:
nntp/NntpArticle.cpp:76:10: error: ‘strcpy’ is not a member of ‘std’; did you mean ‘strcpy’?
   76 |     std::strcpy(_body, body.c_str());
      |          ^~~~~~
/usr/include/string.h:141:14: note: ‘strcpy’ declared here
  141 | extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
      |              ^~~~~~
make: *** [Makefile:968: NntpArticle.o] Error 1
```

This PR fix that